### PR TITLE
[FIX] project_forecast_line: handle lack of project status

### DIFF
--- a/project_forecast_line/models/project_task.py
+++ b/project_forecast_line/models/project_task.py
@@ -80,6 +80,9 @@ class ProjectTask(models.Model):
                 if not forecast_type:
                     _logger.info("skip task %s: no forecast for project state", task)
                     continue  # closed / cancelled stage
+            elif not task.project_id.project_status:
+                _logger.info("skip task %s: no project status set", task)
+                continue  # not status on project
             elif task.sale_line_id:
                 sale_state = task.sale_line_id.state
                 if sale_state == "cancel":


### PR DESCRIPTION
In some cases you can have a project without a status set -> in this case we don't want to generate forecast lines (and we don't want a crash either)