### PR TITLE
[IMP] sudo computation, so that portal users will be able to compute

### DIFF
--- a/project_forecast_line/models/project_task.py
+++ b/project_forecast_line/models/project_task.py
@@ -92,6 +92,7 @@ class ProjectTask(models.Model):
         # can only update the forecast lines by applying a ratio
         ForecastLine = self.env["forecast.line"].sudo()
         for task in self:
+            task = task.sudo()
             forecast_lines = ForecastLine.search(
                 [("res_model", "=", self._name), ("res_id", "=", task.id)]
             )
@@ -151,7 +152,8 @@ class ProjectTask(models.Model):
         ForecastLine = self.env["forecast.line"].sudo()
         task_with_lines_to_clean = []
         for task in self:
-            task = task.with_company(task.company_id)
+            # cannot fail if access to a model, such as project_status, not present
+            task = task.with_company(task.company_id).sudo()
             if not task._should_have_forecast():
                 task_with_lines_to_clean.append(task.id)
                 continue


### PR DESCRIPTION
correctly.

@ntsirintanis  This was needed because now in our portal we change planned_hours , wich triggers remaining_hours, wich  triggers the forecast recompute.
As portal user, even if i sudo the controller in portal code (I do) , the compute keeps on running with UID=portaluser.
Portal user has no access to project_status model, so :

We had 2 solutions , 
             1. Add the permission for portal users ( the conly missing was read access to projec.status model.
             ` project_status_portal_read, Project.status read access for portal,project_status.model_project_status,base.group_portal,1,0,0,0`

             2.  sudo the compute. It does no harm to correctly recompute the forecast every time, no matter the user. 


we went with the second.