### PR TITLE
[FIX] mixin should be Abstract model

### DIFF
--- a/project_forecast_line/models/forecast_line_mixin.py
+++ b/project_forecast_line/models/forecast_line_mixin.py
@@ -3,7 +3,7 @@
 from odoo import api, models
 
 
-class ForecastLineModelMixin(models.Model):
+class ForecastLineModelMixin(models.AbstractModel):
     _name = "forecast.line.mixin"
     _description = "mixin for models which generate forecast lines"
 


### PR DESCRIPTION
Mixin was made as normal model.  generated errors and caused a lot of unwanted data.